### PR TITLE
:wrench: Fix for Role not inside the required context

### DIFF
--- a/js/lc-offcanvas.js
+++ b/js/lc-offcanvas.js
@@ -14,4 +14,10 @@
         $('.off-canvas > ul#menu-main-nav').removeAttr( "role" );
         $('.off-canvas > ul#menu-main-nav > li').removeAttr( "role" );**/
 	}
+    
+    $('ul.accordion').removeAttr( "role" );
+    $('a.accordion-title').removeAttr( "role" );
+
+    $('li.tabs-title').removeAttr( "role" );
+    $('li.tabs-title a').removeAttr( "role" );
  }); 


### PR DESCRIPTION
Removing role from tab group and tab elements on Sage & Seed Menu page.